### PR TITLE
modify the wrong list name of schedule_unit to interval_uint

### DIFF
--- a/disaster_recovery/jobs/workflows/create.py
+++ b/disaster_recovery/jobs/workflows/create.py
@@ -161,13 +161,13 @@ class InfoConfigurationAction(workflows.Action):
 
         if (cleaned_data.get('schedule_start_date') and
                 cleaned_data.get('schedule_end_date')) and\
-                not cleaned_data.get('schedule_unit'):
+                not cleaned_data.get('interval_uint'):
             msg = _("Please provide this value.")
-            self._errors['schedule_unit'] = self.error_class([msg])
+            self._errors['interval_uint'] = self.error_class([msg])
 
         if (cleaned_data.get('schedule_end_date') and
                 not cleaned_data.get('schedule_start_date')) and\
-                not cleaned_data.get('schedule_unit'):
+                not cleaned_data.get('interval_uint'):
             msg = _("Please provide this value.")
             self._errors['schedule_start_date'] = self.error_class([msg])
 


### PR DESCRIPTION
when I create job, there is an error in Django.
`BaseForm.is_valid errors:<ul class="errorlist"><li>schedule_unit<ul class="errorlist"><li>Please provide this value.</li></ul></li></ul>`